### PR TITLE
Add get scores

### DIFF
--- a/Searches/searches.py
+++ b/Searches/searches.py
@@ -24,7 +24,6 @@ def response_handler(response):
         raise RuntimeError("Failed to send Invalid Request") from e
 
     if code < 200 or code >= 300:
-
         # print(f"Error {code}: {error_message}")
         # raise Exception(f"Error {code}: {error_message}")
         error_message = json.loads(response.content)
@@ -72,6 +71,38 @@ class Search:
 
         logging.debug(f"Http Destination: {URL}")
         r = requests.get(URL, headers=head, params=parameters)
+        logging.debug(f"Request Type: {r.request}")
+        logging.debug(f"Status Code: {r.status_code}")
+        check = response_handler(r)
+        if check != 0:
+            return -1
+        dictionary_data = json.loads(r.content)
+        return dictionary_data
+
+    # This endpoint returns a risk score for scope, category, and attributes based on a series of specified parameters
+    # Uses purl spec https://github.com/package-url/purl-spec#purl
+    def get_score(self, name, org, pkg_type, tb=None):
+        """
+        Will perform a search for a risk score based on a series of specified parameters
+        Uses purl spec https://github.com/package-url/purl-spec#purl
+        :param name: (String) The name of the package. Required.
+        :param org: (String) Some name prefix such as a Maven groupid, a Docker image owner, a GitHub user or organization. Optional and type-specific.
+        :param pkg_type: (String) The package "type" or package "protocol" such as maven, npm, nuget, gem, pypi, github, etc. Required.
+        :param tb: (String) Optional parameter that indicates what package type is set.
+        :return: (Dictionary) or (Integer) Will return a dictionary object containing score results retrieved from the API, if errored will return -1 or throw an Exception
+        """
+        endpoint = "score/getScore?purl=pkg:"
+        if tb == 'repos':
+            pkg_type = 'github'
+        elif tb == 'products':
+            pkg_type = 'TBA'
+        elif tb == 'packages':
+            pkg_type = 'TBA'
+        query = '/' + org + '/' + name
+        head = {"Authorization": "Bearer " + self.token}
+        URL = self.baseURL + endpoint + pkg_type + query
+        logging.debug(f"Http Destination: {URL}")
+        r = requests.get(URL, headers=head)
         logging.debug(f"Request Type: {r.request}")
         logging.debug(f"Status Code: {r.status_code}")
         check = response_handler(r)

--- a/Searches/searches.py
+++ b/Searches/searches.py
@@ -92,13 +92,13 @@ class Search:
         :return: (Dictionary) or (Integer) Will return a dictionary object containing score results retrieved from the API, if errored will return -1 or throw an Exception
         """
         endpoint = "score/getScore?purl=pkg:"
-        if tb == 'repos':
-            pkg_type = 'github'
-        elif tb == 'products':
-            pkg_type = 'TBA'
-        elif tb == 'packages':
-            pkg_type = 'TBA'
-        query = '/' + org + '/' + name
+        if tb == "repos":
+            pkg_type = "github"
+        elif tb == "products":
+            pkg_type = "TBA"
+        elif tb == "packages":
+            pkg_type = "TBA"
+        query = "/" + org + "/" + name
         head = {"Authorization": "Bearer " + self.token}
         URL = self.baseURL + endpoint + pkg_type + query
         logging.debug(f"Http Destination: {URL}")


### PR DESCRIPTION
I left TBA for future methods of accessing different package types that isn't on github specifically. However, this hasn't been implemented yet from data services. For now, this works with milestone 1.75.

I could remove tb if statements, but I thought maybe it would keep it more consistent like when using search and tb='repos'/'products'/'packages/'reports'